### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ First install the Rust compiler via https://rustup.rs, then run `cargo install m
 
 ## Usage
 
-Create a multirun.toml file, then run `multirun`.
+Create a multirun.json file, then run `multirun`.


### PR DESCRIPTION
Changes "multirun.toml" to "multirun.json" because the config isn't supposed to be toml (I think)